### PR TITLE
Поддержка доменов и SRV-записей

### DIFF
--- a/Pingo.Example/Pingo.Example.csproj
+++ b/Pingo.Example/Pingo.Example.csproj
@@ -11,4 +11,8 @@
       <ProjectReference Include="..\Pingo\Pingo.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="DnsClient" Version="1.8.0" />
+    </ItemGroup>
+
 </Project>

--- a/Pingo.Example/Program.cs
+++ b/Pingo.Example/Program.cs
@@ -1,20 +1,16 @@
 ﻿using Pingo;
 using Pingo.Status;
 
-var options = new MinecraftPingOptions
-{
+var options = new MinecraftPingOptions {
     Address = "127.0.0.1",
     Port = 25565
 };
 
 var status = await Minecraft.PingAsync(options);
 
-if (status is BedrockStatus bedrock)
-{
+if (status is BedrockStatus bedrock) {
     Console.WriteLine(string.Join(", ", bedrock.MessagesOfTheDay));
-}
-else
-{
-    var java = (JavaStatus?) status;
+} else {
+    var java = (JavaStatus?)status;
     Console.WriteLine(string.Join(", ", java!.MessagesOfTheDay));
 }

--- a/Pingo/Pingo.csproj
+++ b/Pingo/Pingo.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="DnsClient" Version="1.8.0" />
       <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="8.0.10" />
       <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>


### PR DESCRIPTION
Вечер добрый, заметил как человек попросил возможность пинговать сервера по домену, а вы отказали, ну а я смотрю и думаю, ну не может все так сложно быть, так и оказалось вот держите пул рикветс.
В общем то, изменил я Pingo/Minecraft.cs и добавил в него проверку если это домен и указан порт, ну и собственно получать сам айпи из домена. Ну а если порт указан 0 и есть домен, тут история веселая, идут попытки получить SRV запись домена, а из него уже сам порт, для этого приключения я закинул пакет DnsClient, вот такие пироги. 
(Не бейте пж за то что скобки перенес в коде, я из джавы выходец, сложно мне со скобками на следующей строке)